### PR TITLE
Add dedicated `lock_fee` method to MayaRouter

### DIFF
--- a/maya_router/Cargo.lock
+++ b/maya_router/Cargo.lock
@@ -791,8 +791,9 @@ dependencies = [
 
 [[package]]
 name = "radix-blueprint-schema-init"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a744eb07ded9effa0a6ab1e3d4dba1707a980ec0acb8ebeb37cdb78b373cd1"
 dependencies = [
  "bitflags 1.3.2",
  "radix-common",
@@ -802,8 +803,9 @@ dependencies = [
 
 [[package]]
 name = "radix-common"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce97ee67264628b4651706ec6808e443fbb0ecba766824a0e94887a5b54969"
 dependencies = [
  "bech32",
  "blake2",
@@ -828,8 +830,9 @@ dependencies = [
 
 [[package]]
 name = "radix-common-derive"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0ac980f09b21f849aa12f2473adfa366e70829ed634f5735512532066f71ad"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -840,8 +843,9 @@ dependencies = [
 
 [[package]]
 name = "radix-engine"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef90ebf947c5222524473247e360e85672d7087069302681fbd2d039e7320164"
 dependencies = [
  "bitflags 1.3.2",
  "colored",
@@ -871,8 +875,9 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-interface"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a96a51e803213f13cf199c92eaafa3884292c1e66d8afc1d8aef7e15625ff0"
 dependencies = [
  "bitflags 1.3.2",
  "const-sha1",
@@ -892,16 +897,18 @@ dependencies = [
 
 [[package]]
 name = "radix-engine-profiling"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2923380e79a504f1825ff9b44af664bcd0abbfb551019ee7f5007902304630"
 dependencies = [
  "fixedstr",
 ]
 
 [[package]]
 name = "radix-engine-profiling-derive"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126e06af580691c53ca3b1a18ba282b47381a060f3fffe7019b6be5fe8c89745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -911,8 +918,9 @@ dependencies = [
 
 [[package]]
 name = "radix-native-sdk"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0506f56ba243c757e11236e3b3fee34282790a4ba7dd99940b1c7d88e21ac48"
 dependencies = [
  "radix-common",
  "radix-engine-interface",
@@ -922,8 +930,9 @@ dependencies = [
 
 [[package]]
 name = "radix-rust"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6010fd7ebd7c2d3a3d270525c54a0dcb43fbaf3447fb32b42a0bcc4326109c64"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -931,8 +940,9 @@ dependencies = [
 
 [[package]]
 name = "radix-sbor-derive"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc92b5760b129af15be9a82fe2e8118aa851da81b22c8a12d56ab494f071321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -942,8 +952,9 @@ dependencies = [
 
 [[package]]
 name = "radix-substate-store-impls"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86105fdc4d31f0ecdfbafe93010c06f3aa6d60794015e1959846920385580111"
 dependencies = [
  "hex",
  "itertools",
@@ -955,8 +966,9 @@ dependencies = [
 
 [[package]]
 name = "radix-substate-store-interface"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0c4e9aa0ffc8851c4d48993167a43fdf6b504e3a506dcd5bd1bd80ac4b73f4"
 dependencies = [
  "hex",
  "itertools",
@@ -967,8 +979,9 @@ dependencies = [
 
 [[package]]
 name = "radix-substate-store-queries"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0099ee240bfd0ce74936e337b655ffbe40af2f30348961ff2c313124185f225"
 dependencies = [
  "hex",
  "itertools",
@@ -984,8 +997,9 @@ dependencies = [
 
 [[package]]
 name = "radix-transactions"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f12b263db56da50ba27fcca074c870a16fd7e4f6a88022f7c4b2ad761e2e11"
 dependencies = [
  "annotate-snippets",
  "bech32",
@@ -1149,8 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "sbor"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d72c7d255b90198cf83c4cc4907021a927f484586939d8d50bdcd045287bde"
 dependencies = [
  "const-sha1",
  "hex",
@@ -1163,8 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a51a6bd2e7849a2a8826a473e83a9a995011af21892acee89e62ce93f0d7c42"
 dependencies = [
  "proc-macro2",
  "sbor-derive-common",
@@ -1173,8 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "sbor-derive-common"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f1209a1d8c81d724c45afc06e41aa4e64a18b389e8cdece53da61bad1c1620"
 dependencies = [
  "const-sha1",
  "itertools",
@@ -1206,8 +1223,9 @@ checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
 name = "scrypto"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc8a64aa6af83ed0dfc588a278c54138d9e7d855cf7b3a22287c5239a964285e"
 dependencies = [
  "bech32",
  "const-sha1",
@@ -1226,8 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "scrypto-compiler"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eeb5034691f2aa354c800f5cd02891075742d9e3e1107dedc640f5517bae665"
 dependencies = [
  "cargo_toml",
  "radix-common",
@@ -1240,8 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "scrypto-derive"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c369a0c3f292e4704bd71d47c80a2d6162b1e0212e9c34f130634ee29e58c0ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1256,8 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "scrypto-test"
-version = "1.2.0-dev"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?rev=b82a7db0a0#b82a7db0a0b2da62ea22a640143cd0caf73b6603"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823380f17d5d2bef61dd4e1f473138704b5302b8cc6ea8ced76394a65719c826"
 dependencies = [
  "ouroboros",
  "paste",

--- a/maya_router/Cargo.toml
+++ b/maya_router/Cargo.toml
@@ -4,13 +4,13 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "b82a7db0a0" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "b82a7db0a0" }
+sbor = { version = "1.2.0" }
+scrypto = { version = "1.2.0" }
 
 [dev-dependencies]
-scrypto-test = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "b82a7db0a0" }
-scrypto-compiler = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "b82a7db0a0" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", rev = "b82a7db0a0" }
+scrypto-test = { version = "1.2.0" }
+scrypto-compiler = { version = "1.2.0" }
+radix-engine = { version = "1.2.0" }
 strum = { version = "0.26.2", features = ["derive"] }
 strum_macros = { version = "0.26.2" }
 

--- a/maya_router/tests/lib.rs
+++ b/maya_router/tests/lib.rs
@@ -580,7 +580,7 @@ fn maya_router_transfer_out_asset_not_available() {
 }
 
 #[test]
-fn maya_router_transfer_out_assert_access_rule_failed_insufficient_balance() {
+fn maya_router_transfer_out_insufficient_balance() {
     // Arrange
     let mut maya_router = MayaRouterSimulator::new();
 
@@ -602,16 +602,11 @@ fn maya_router_transfer_out_assert_access_rule_failed_insufficient_balance() {
 
     // Assert
     receipt.expect_specific_rejection(|e| match e {
-        RejectionReason::ErrorBeforeLoanAndDeferredCostsRepaid(RuntimeError::SystemError(
-            SystemError::TypeCheckError(TypeCheckError::BlueprintPayloadValidationError(
-                _,
-                BlueprintPayloadIdentifier::Function(func_name, _),
-                s,
+        RejectionReason::ErrorBeforeLoanAndDeferredCostsRepaid(
+            RuntimeError::SystemModuleError(SystemModuleError::CostingError(
+                CostingError::FeeReserveError(FeeReserveError::InsufficientBalance { .. }),
             )),
-        )) => {
-            func_name.eq("assert_access_rule")
-                && s.contains("SystemModuleError(CostingError(FeeReserveError(InsufficientBalance")
-        }
+        ) => true,
         _ => false,
     });
 }

--- a/maya_router/tests/lib.rs
+++ b/maya_router/tests/lib.rs
@@ -55,10 +55,6 @@ struct MayaRouterSimulator {
 impl MayaRouterSimulator {
     const BLUEPRINT_NAME: &'static str = "MayaRouter";
 
-    pub fn manifest_builder_with_faucet_fee() -> ManifestBuilder {
-        ManifestBuilder::new().lock_fee_from_faucet()
-    }
-
     pub fn create_component(ledger: &mut DefaultLedgerSimulator) -> TransactionReceipt {
         let mut compiler = ScryptoCompiler::builder()
             .manifest_path(this_package!())
@@ -69,7 +65,8 @@ impl MayaRouterSimulator {
         let package_address = ledger
             .publish_package_simple((artifacts.wasm.content, artifacts.package_definition.content));
         ledger.execute_manifest(
-            Self::manifest_builder_with_faucet_fee()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_function(
                     package_address,
                     Self::BLUEPRINT_NAME,
@@ -129,7 +126,8 @@ impl MayaRouterSimulator {
     pub fn set_only_swapper_can_deposit(&mut self) {
         let badge = ResourceOrNonFungible::NonFungible(self.swapper.badge.clone());
         self.ledger.execute_manifest(
-            Self::manifest_builder_with_faucet_fee()
+            ManifestBuilder::new()
+                .lock_fee_from_faucet()
                 .call_method(
                     self.swapper.address,
                     ACCOUNT_SET_DEFAULT_DEPOSIT_RULE_IDENT,
@@ -163,7 +161,8 @@ impl MayaRouterSimulator {
         amount: Decimal,
         memo: &str,
     ) -> TransactionReceipt {
-        let manifest = Self::manifest_builder_with_faucet_fee()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .withdraw_from_account(from, asset, amount)
             .take_all_from_worktop(asset, "bucket")
             .with_bucket("bucket", |builder, bucket| {
@@ -187,12 +186,8 @@ impl MayaRouterSimulator {
         memo: &str,
         fee_to_lock: Decimal,
     ) -> TransactionReceipt {
-        let builder = if fee_to_lock <= 0.into() {
-            Self::manifest_builder_with_faucet_fee()
-        } else {
-            ManifestBuilder::new()
-        };
-        let manifest = builder
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.component_address,
                 "withdraw",
@@ -224,7 +219,8 @@ impl MayaRouterSimulator {
         memo: &str,
         fee_to_lock: Decimal,
     ) -> TransactionReceipt {
-        let manifest = Self::manifest_builder_with_faucet_fee()
+        let manifest = ManifestBuilder::new()
+            .lock_fee_from_faucet()
             .call_method(
                 self.component_address,
                 "withdraw",
@@ -351,7 +347,8 @@ fn maya_router_deposit_and_transfer_out_success() {
             TransferOut::LockerUsed => {
                 let locker = maya_router.get_account_locker().unwrap();
 
-                let manifest = MayaRouterSimulator::manifest_builder_with_faucet_fee()
+                let manifest = ManifestBuilder::new()
+                    .lock_fee_from_faucet()
                     .call_method(
                         locker,
                         "claim",
@@ -384,7 +381,8 @@ fn maya_router_deposit_sender_non_real_account() {
     let swap_memo = "SWAP:MAYA.CACAO";
 
     // Act
-    let manifest = MayaRouterSimulator::manifest_builder_with_faucet_fee()
+    let manifest = ManifestBuilder::new()
+        .lock_fee_from_faucet()
         .withdraw_from_account(maya_router.swapper.address, XRD, dec!(100))
         .take_all_from_worktop(XRD, "bucket")
         .with_bucket("bucket", |builder, bucket| {


### PR DESCRIPTION
`lock_fee` method will lock fee from given vault address.
Previously fee was locked internally in `withdraw` method. But since the `withdraw` has pretty large number of arguments of complex types, where some of them were being virtualized (eg. `intended_recipient`), which was consuming quickly a fee loan, causing sometimes fee reserve insufficient balance error.

Now `lock_fee` has a minimal number of arguments, which should not be virtualized.

Additional changes:

- tests updated to use non initialized Asgard Vaults 
- if applicable tests updated to not use fee from faucet but to use above `lock_fee` method
- bump deps to scrypto 1.2.0